### PR TITLE
Adding url for license 

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -70,7 +70,7 @@
     {
       "@id": "https://w3id.org/dats/schema/license_schema.json",
       "@type": "License",
-      "name": "PREVENT-AD proprietary",
+      "name": "https://openpreventad.loris.ca/images/Open_PREVENT-AD_Terms_of_Use.png",
       "extraProperties": [
 	{
           "category": "dataUsesConditions",


### PR DESCRIPTION
This PR updates the _license->name_ field in DATS.json to a URL pointing to the PreventAD Terms of Use.