### PR TITLE
forcing datalad to ask for credentials when downloading dataset

### DIFF
--- a/.datalad/config
+++ b/.datalad/config
@@ -1,2 +1,5 @@
 [datalad "dataset"]
 	id = eab6dcc6-4f48-11ea-939f-525400a81463
+[credentials]
+	force-ask = true
+

--- a/.datalad/config
+++ b/.datalad/config
@@ -1,3 +1,4 @@
 [datalad "dataset"]
 	id = eab6dcc6-4f48-11ea-939f-525400a81463
-
+[credentials]
+	force-ask = true

--- a/.datalad/config
+++ b/.datalad/config
@@ -1,5 +1,3 @@
 [datalad "dataset"]
 	id = eab6dcc6-4f48-11ea-939f-525400a81463
-[credentials]
-	force-ask = true
 

--- a/.datalad/providers/loris.cfg
+++ b/.datalad/providers/loris.cfg
@@ -3,10 +3,8 @@ url_re = https:\/\/openpreventad.loris.ca\/.*
 credential = loris-prevent-ad
 authentication_type = loris-token
 loris-token_failure_re = "User not authenticated"}$
-
 [credential:loris-prevent-ad]
 url = https://openpreventad.loris.ca/api/v0.0.3-dev/login
 type = loris-token
-force-ask = true
 
 

--- a/.datalad/providers/loris.cfg
+++ b/.datalad/providers/loris.cfg
@@ -7,4 +7,6 @@ loris-token_failure_re = "User not authenticated"}$
 [credential:loris-prevent-ad]
 url = https://openpreventad.loris.ca/api/v0.0.3-dev/login
 type = loris-token
+force-ask = true
+
 

--- a/DATS.json
+++ b/DATS.json
@@ -42,12 +42,14 @@
   "types": [
     {
       "information": {
-        "value": "MRI"
+        "value": "MRI",
+		"valueIRI": "http://uri.interlex.org/ilx_0779748"
       }
     },
     {
       "information": {
-        "value": "basic demographics"
+        "value": "basic demographics",
+		"valueIRI": "http://uri.interlex.org/ilx_0103016"
       }
     }
   ],


### PR DESCRIPTION
This PR updates `.datalad/config` to include the lines:

`
[credentials]
force-ask = true
`
to require the user to resubmit username and password with each download, hence avoiding the problem of downloads hanging indefinitely as each individual file is tested with an invalid login and waits for multiple minutes to time out.

It also updates `DATS.json` with interlex links for the values in `types`.